### PR TITLE
Url extensions update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install -y pdftk
   - sudo apt-get install -y ghostscript
-  - curl -OL https://mupdf.com/downloads/mupdf-1.12-source.tar.gz
-  - tar zvxf mupdf-1.12-source.tar.gz && cd mupdf-1.12-source && sudo make && sudo make install
+  - curl -OL https://mupdf.com/downloads/mupdf-1.12.0-source.tar.gz
+  - tar zvxf mupdf-1.12.0-source.tar.gz && cd mupdf-1.12.0-source && sudo make && sudo make install
   - sudo apt-get install -y gobject-introspection libgirepository1.0-dev libglib2.0-dev libpoppler-glib-dev
   - curl -OL https://github.com/jcupitt/libvips/releases/download/v8.5.8/vips-8.5.8.tar.gz
   - tar zvxf vips-8.5.8.tar.gz && cd vips-8.5.8 && ./configure && sudo make && sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install -y pdftk
   - sudo apt-get install -y ghostscript
-  - sudo apt-get install -y mupdf-tools
+  - wget https://mupdf.com/downloads/mupdf-1.12-source.tar.gz
+  - tar zvxf mupdf-1.12-source.tar.gz && cd mupdf-1.12-source && sudo make && sudo make install
   - sudo apt-get install -y gobject-introspection libgirepository1.0-dev libglib2.0-dev libpoppler-glib-dev
   - curl -OL https://github.com/jcupitt/libvips/releases/download/v8.5.8/vips-8.5.8.tar.gz
   - tar zvxf vips-8.5.8.tar.gz && cd vips-8.5.8 && ./configure && sudo make && sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install -y pdftk
   - sudo apt-get install -y ghostscript
-  - wget https://mupdf.com/downloads/mupdf-1.12-source.tar.gz
+  - curl -OL https://mupdf.com/downloads/mupdf-1.12-source.tar.gz
   - tar zvxf mupdf-1.12-source.tar.gz && cd mupdf-1.12-source && sudo make && sudo make install
   - sudo apt-get install -y gobject-introspection libgirepository1.0-dev libglib2.0-dev libpoppler-glib-dev
   - curl -OL https://github.com/jcupitt/libvips/releases/download/v8.5.8/vips-8.5.8.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - sudo apt-get install -y pdftk
   - sudo apt-get install -y ghostscript
   - curl -OL https://mupdf.com/downloads/mupdf-1.12.0-source.tar.gz
-  - tar zvxf mupdf-1.12.0-source.tar.gz && cd mupdf-1.12.0-source && sudo make && sudo make install
+  - tar zvxf mupdf-1.12.0-source.tar.gz && cd mupdf-1.12.0-source && sudo make HAVE_X11=no HAVE_GLUT=no prefix=/usr/local install
   - sudo apt-get install -y gobject-introspection libgirepository1.0-dev libglib2.0-dev libpoppler-glib-dev
   - curl -OL https://github.com/jcupitt/libvips/releases/download/v8.5.8/vips-8.5.8.tar.gz
   - tar zvxf vips-8.5.8.tar.gz && cd vips-8.5.8 && ./configure && sudo make && sudo make install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 2.0.1
 
-* fixed: `:page_thumb` and `:convert` now correctly updates meta data and extension on the url
+* fixed: a bug in Convert and Page Thumb Processors which caused the url to not include file extension
+* refactored: Page Thumb Processor is now a class
+* added: tests for Convert and Page Thumb Processor
 
 ## 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.0.1
+
+* fixed: `:page_thumb` and `:convert` now correctly updates meta data and extension on the url
+
 ## 2.0.0
 
 * PDF rendering to use `mupdf` which results in siginificant performance boost

--- a/lib/dragonfly_pdf/plugin.rb
+++ b/lib/dragonfly_pdf/plugin.rb
@@ -4,6 +4,7 @@ require 'dragonfly_pdf/analysers/pdf_properties'
 
 require 'dragonfly_pdf/processors/append'
 require 'dragonfly_pdf/processors/convert'
+require 'dragonfly_pdf/processors/page_thumb'
 require 'dragonfly_pdf/processors/page'
 require 'dragonfly_pdf/processors/remove_password'
 require 'dragonfly_pdf/processors/rotate'
@@ -49,25 +50,8 @@ module DragonflyPdf
       app.add_processor :rotate, DragonflyPdf::Processors::Rotate.new
       app.add_processor :stamp, DragonflyPdf::Processors::Stamp.new
       app.add_processor :subset_fonts, DragonflyPdf::Processors::SubsetFonts.new
-
       app.add_processor :thumb, DragonflyLibvips::Processors::Thumb.new
-
-      app.add_processor :page_thumb do |content, page, geometry = nil, options = {}|
-        options = options.deep_symbolize_keys
-        options[:format] = options.fetch(:format, :jpg)
-
-        convert_options = {}
-        convert_options[:format] = case options[:format]
-                                   when :pdf, :svg then options[:format]
-                                   else :png
-        end
-
-        content.process!(:convert, page, geometry, convert_options)
-
-        unless %i[pdf png svg].include?(options[:format].to_sym)
-          content.process!(:thumb, geometry, options)
-        end
-      end
+      app.add_processor :page_thumb, DragonflyPdf::Processors::PageThumb.new
     end
   end
 end

--- a/lib/dragonfly_pdf/processors/convert.rb
+++ b/lib/dragonfly_pdf/processors/convert.rb
@@ -50,14 +50,16 @@ module DragonflyPdf
           `mv #{content.path.sub(".#{format}", "1.#{format}")} #{content.path}`
         end
 
+        content.meta['format'] = format.to_s
         content.ext = format
+        content.meta['mime_type'] = nil # don't need it as we have ext now
       end
 
-      def update_url(url_attributes, _, options = {})
+      def update_url(attrs, page, geometry=nil, options = {})
         options = options.deep_symbolize_keys
         format = options.fetch(:format, :png)
 
-        url_attributes.ext = format
+        attrs.ext = format.to_s
       end
 
       private

--- a/lib/dragonfly_pdf/processors/page_thumb.rb
+++ b/lib/dragonfly_pdf/processors/page_thumb.rb
@@ -1,0 +1,40 @@
+module DragonflyPdf
+  module Processors
+    class PageThumb
+      def call(content, page, geometry = nil, options = {})
+        options = options.deep_symbolize_keys
+        format = options.delete(:format) { :jpg }
+
+        convert(content, page, geometry, format)
+
+        unless %i[pdf png svg].include?(format.to_sym)
+          thumb(content, geometry, format, options)
+        end
+
+        content.meta['format'] = format.to_s
+        content.ext = format
+        content.meta['mime_type'] = nil # don't need it as we have ext now
+      end
+
+      def update_url(attrs, page, geometry=nil, options = {})
+        options = options.deep_symbolize_keys
+        format = options.fetch(:format, :jpg)
+        attrs.ext = format.to_s
+      end
+
+      private # =============================================================
+
+      def convert(content, page, geometry, format)
+        convert_format = case format
+                         when :pdf, :svg then format
+                         else :png
+        end
+        content.process!(:convert, page, geometry, { format: convert_format })
+      end
+
+      def thumb(content, geometry, format, options)
+        content.process!(:thumb, geometry, options.merge(format: format))
+      end
+    end
+  end
+end

--- a/test/dragonfly_pdf/plugin_test.rb
+++ b/test/dragonfly_pdf/plugin_test.rb
@@ -68,29 +68,5 @@ module DragonflyPdf
         pdf.convert(1, '600x').url.must_match /\.png/
       end
     end
-
-    describe 'DragonflyLibvips proxy' do
-      describe 'page_thumb' do
-        it 'creates a JPG' do
-          pdf.page_thumb!(1, '600x')
-          `file --mime-type #{pdf.path}`.must_include 'image/jpeg'
-          pdf.ext.must_equal 'jpg'
-        end
-
-        it 'adds the correct extension to resulting url' do
-          pdf.page_thumb!(1, '600x').url.must_match /\.jpg/
-        end
-
-        it 'converts PDF page to SVG format' do
-          pdf.page_thumb!(1, nil, format: :svg)
-          `file --mime-type #{pdf.path}`.must_include 'image/svg+xml'
-        end
-
-        it 'converts PDF page to PDF format' do
-          pdf.page_thumb!(1, nil, format: :pdf)
-          `file --mime-type #{pdf.path}`.must_include 'application/pdf'
-        end
-      end
-    end
   end
 end

--- a/test/dragonfly_pdf/plugin_test.rb
+++ b/test/dragonfly_pdf/plugin_test.rb
@@ -63,22 +63,33 @@ module DragonflyPdf
       end
     end
 
+    describe '#convert' do
+      it 'adds the correct extension to resulting url' do
+        pdf.convert(1, '600x').url.must_match /\.png/
+      end
+    end
+
     describe 'DragonflyLibvips proxy' do
       describe 'page_thumb' do
-        it 'converts PDF to JPG format' do
+        it 'creates a JPG' do
           pdf.page_thumb!(1, '600x')
           `file --mime-type #{pdf.path}`.must_include 'image/jpeg'
+          pdf.ext.must_equal 'jpg'
         end
 
-        # it 'converts PDF page to SVG format' do
-        #   pdf.page_thumb!(1, nil, format: :svg)
-        #   `file --mime-type #{pdf.path}`.must_include 'image/svg+xml'
-        # end
-        #
-        # it 'converts PDF page to PDF format' do
-        #   pdf.page_thumb!(1, nil, format: :pdf)
-        #   `file --mime-type #{pdf.path}`.must_include 'application/pdf'
-        # end
+        it 'adds the correct extension to resulting url' do
+          pdf.page_thumb!(1, '600x').url.must_match /\.jpg/
+        end
+
+        it 'converts PDF page to SVG format' do
+          pdf.page_thumb!(1, nil, format: :svg)
+          `file --mime-type #{pdf.path}`.must_include 'image/svg+xml'
+        end
+
+        it 'converts PDF page to PDF format' do
+          pdf.page_thumb!(1, nil, format: :pdf)
+          `file --mime-type #{pdf.path}`.must_include 'application/pdf'
+        end
       end
     end
   end

--- a/test/dragonfly_pdf/processors/convert_test.rb
+++ b/test/dragonfly_pdf/processors/convert_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+describe DragonflyPdf::Processors::Convert do
+  let(:app) { test_app.configure_with(:pdf) }
+  let(:sample) { Dragonfly::Content.new(app, SAMPLES_DIR.join('sample_pages.pdf')) }
+
+  let(:processor) { DragonflyPdf::Processors::Convert.new }
+
+  describe 'formats' do
+    let (:url_attributes) { OpenStruct.new }
+
+    describe 'default' do
+      before { processor.call(sample, 1, '600x') }
+
+      it 'converts the PDF to a PNG by default' do
+        sample.ext.must_equal 'png'
+      end
+
+      it 'updates the file meta format to PNG by default' do
+        sample.meta['format'].must_equal 'png'
+      end
+
+      it 'updates the url extension to PNG by default' do
+        processor.update_url(url_attributes, 1)
+        url_attributes.ext.must_equal 'png'
+      end
+    end
+
+    describe 'svg' do
+      before { processor.call(sample, 1, '600x', format: :svg) }
+
+      it 'converts the PDF to an SVG' do
+        sample.ext.must_equal 'svg'
+      end
+
+      it 'updates the file meta format to SVG' do
+        sample.meta['format'].must_equal 'svg'
+      end
+
+      it 'updates the url extension to SVG' do
+        processor.update_url(url_attributes, 1, '', format: :svg)
+        url_attributes.ext.must_equal 'svg'
+      end
+    end
+  end
+end

--- a/test/dragonfly_pdf/processors/page_thumb_test.rb
+++ b/test/dragonfly_pdf/processors/page_thumb_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+describe DragonflyPdf::Processors::PageThumb do
+  let(:app) { test_app.configure_with(:pdf) }
+  let(:sample) { Dragonfly::Content.new(app, SAMPLES_DIR.join('sample_pages.pdf')) }
+
+  let(:processor) { DragonflyPdf::Processors::PageThumb.new }
+
+  describe 'formats' do
+    let (:url_attributes) { OpenStruct.new }
+
+    describe 'default' do
+      before { processor.call(sample, 1, '600x') }
+
+      it 'converts the PDF to a JPG by default' do
+        sample.ext.must_equal 'jpg'
+      end
+
+      it 'updates the file meta format to JPG by default' do
+        sample.meta['format'].must_equal 'jpg'
+      end
+
+      it 'updates the url extension to JPG by default' do
+        processor.update_url(url_attributes, 1)
+        url_attributes.ext.must_equal 'jpg'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes a bug with the file extensions in the url not updating when using Convert and Page Thumb Processors.

Page Thumb Processor has been refactored to a class.

Tests have been added for both Convert and Page Thumb Processor.